### PR TITLE
Update MemTable.php

### DIFF
--- a/src/MemTable.php
+++ b/src/MemTable.php
@@ -191,6 +191,7 @@ class MemTable
      */
     public function get(string $key, string $field = null)
     {
+        if(is_null($field)) return $this->getTable()->get($key);
         return $this->getTable()->get($key, $field);
     }
 


### PR DESCRIPTION
修复没有传field的情况下报出的`(TypeError) Swoole\\Table::get() expects parameter 2 to be string, null given`错误